### PR TITLE
Fix Omni build by adding Cargo support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "omni"
+version = "0.1.0"
+edition = "2021"
+authors = ["therealcoolnerd"]
+license = "AGPL-3.0-or-later"
+description = "Universal Linux Installer Engine"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yaml = "0.9"
+chrono = { version = "0.4", features = ["serde"] }
+

--- a/src/boxes/mod.rs
+++ b/src/boxes/mod.rs
@@ -1,0 +1,3 @@
+pub mod apt;
+pub mod pacman;
+pub mod flatpak;


### PR DESCRIPTION
## Summary
- add `Cargo.toml` with dependencies
- make `boxes` a proper module by adding `mod.rs`

## Testing
- `cargo check --quiet` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_6840f5c1dda483338d60de314272480c