### PR TITLE
Remove binary from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 # Generated lock file
 Cargo.lock
+# Release artifacts
+release/

--- a/README.md
+++ b/README.md
@@ -18,20 +18,27 @@ With modular **Omni Boxes**, a secure **Omni Brain**, and the high-speed **Omni 
   letting you install packages directly or select a manifest with a file picker.
 
 ## 🚀 Getting Started
-```bash
-git clone https://github.com/therealcoolnerd/omni.git
-cd omni
-cargo build
-./target/debug/omni install --from omni.manifest.yaml
-# Launch the GUI
-./target/debug/omni gui
-# View command help
-./target/debug/omni help
 
-# If you use Nix, run this first to get all dependencies
-# and an editor with rust-analyzer preinstalled
-nix develop
-```
+You can either grab a prebuilt binary or build Omni yourself.
+
+- **Download:** Visit the [GitHub Releases](https://github.com/therealcoolnerd/omni/releases)
+  page and download `omni-linux.gz`. Extract it with `gzip -d omni-linux.gz`
+  and run `./omni`.
+- **Build:**
+  ```bash
+  git clone https://github.com/therealcoolnerd/omni.git
+  cd omni
+  cargo build
+  ./target/debug/omni install --from omni.manifest.yaml
+  # Launch the GUI
+  ./target/debug/omni gui
+  # View command help
+  ./target/debug/omni help
+
+  # If you use Nix, run this first to get all dependencies
+  # and an editor with rust-analyzer preinstalled
+  nix develop
+  ```
 
 ## 📜 License
 GNU AGPLv3


### PR DESCRIPTION
## Summary
- ignore the release directory
- instruct users to download `omni-linux.gz` from GitHub releases or build from source

## Testing
- `cargo check`

------
https://chatgpt.com/codex/tasks/task_e_68455c776678833383502c7adcc0e826