### PR TITLE
Silence unused manifest fields

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -3,7 +3,9 @@ use std::fs;
 
 #[derive(Debug, Deserialize)]
 pub struct OmniManifest {
+    #[allow(dead_code)]
     pub project: String,
+    #[allow(dead_code)]
     pub description: Option<String>,
     pub apps: Vec<OmniApp>,
     pub meta: Option<MetaInfo>,
@@ -14,13 +16,16 @@ pub struct OmniApp {
     pub name: String,
     #[serde(rename = "box")]
     pub box_type: String,
+    #[allow(dead_code)]
     pub version: Option<String>,
     pub source: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct MetaInfo {
+    #[allow(dead_code)]
     pub created_by: Option<String>,
+    #[allow(dead_code)]
     pub created_on: Option<String>,
     pub distro_fallback: Option<bool>,
 }


### PR DESCRIPTION
## Summary
- mark manifest fields used only for deserialization to avoid dead code warnings

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_68461c8c92bc83338cc0de525998d1f0