### PR TITLE
Document upstream remote and enforce in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Verify upstream repository
+      run: |
+        if [ "$GITHUB_REPOSITORY" != "therealcoolnerd/omni" ]; then
+          echo "Publishing is only allowed from the upstream repository" && exit 1
+        fi
+
   build-release:
     name: Build Release
     runs-on: ${{ matrix.os }}
@@ -162,8 +168,13 @@ jobs:
     needs: build-release
     runs-on: macos-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    
+
     steps:
+    - name: Verify upstream repository
+      run: |
+        if [ "$GITHUB_REPOSITORY" != "therealcoolnerd/omni" ]; then
+          echo "Publishing is only allowed from the upstream repository" && exit 1
+        fi
     - name: Update Homebrew formula
       uses: mislav/bump-homebrew-formula-action@65542ba63f8a8b4ef91a5b30d15b8e324a6bb6ff
       with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,9 @@
 git clone https://github.com/your-username/omni.git
 cd omni
 
+# Keep the official repo handy
+git remote add upstream https://github.com/therealcoolnerd/omni.git
+
 # 2. Create your feature branch
 git checkout -b feature/game-changing-feature
 
@@ -29,6 +32,13 @@ git commit -m "feat: add feature that changes everything"
 # 5. Push & PR
 git push origin feature/game-changing-feature
 # Then open a Pull Request on GitHub
+```
+
+Maintainers preparing a release should ensure `origin` points to the
+official repository:
+
+```bash
+git remote set-url origin https://github.com/therealcoolnerd/omni.git
 ```
 
 **That's it.** No complex setup, no bureaucracy—just good code solving real problems.


### PR DESCRIPTION
## Summary
- clarify upstream remote configuration in CONTRIBUTING.md
- fail release workflow if running outside upstream repository

## Testing
- `cargo test` *(fails: no method named `set_network_access` found)*

------
https://chatgpt.com/codex/tasks/task_e_6869f0b8f8408333b9f27cb43134d928