### PR TITLE
Add tests for CSP and DOMPurify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 Cargo.lock
 # Release artifacts
 release/
+web-app/node_modules/

--- a/web-app/src/tests/cspHeader.test.js
+++ b/web-app/src/tests/cspHeader.test.js
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('CSP Meta Tag', () => {
+  test('public index.html includes Content Security Policy header', () => {
+    const filePath = path.resolve(__dirname, '../../public/index.html');
+    const html = fs.readFileSync(filePath, 'utf8');
+    expect(html).toMatch(/<meta[^>]+http-equiv=["']Content-Security-Policy["']/i);
+  });
+});

--- a/web-app/src/tests/dompurifyUsage.test.js
+++ b/web-app/src/tests/dompurifyUsage.test.js
@@ -1,0 +1,22 @@
+import DOMPurify from 'dompurify';
+import { getSafeDisplayName, sanitizeUserContent } from '../utils/validation';
+
+describe('DOMPurify Integration', () => {
+  test('getSafeDisplayName output matches DOMPurify sanitization', () => {
+    const input = '<script>alert(1)</script>John';
+    const expected = DOMPurify.sanitize(input, {
+      ALLOWED_TAGS: [],
+      ALLOWED_ATTR: []
+    }).trim().substring(0, 50) || 'Anonymous User';
+    expect(getSafeDisplayName(input)).toBe(expected);
+  });
+
+  test('sanitizeUserContent output matches DOMPurify sanitization', () => {
+    const content = '<p onclick="alert(1)">hi</p>';
+    const expected = DOMPurify.sanitize(content, {
+      ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u'],
+      ALLOWED_ATTR: []
+    });
+    expect(sanitizeUserContent(content)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- confirm CSP meta tag is included
- add tests checking DOMPurify usage matches expectations

## Testing
- `npm test -- --testPathPattern=src/tests`

------
https://chatgpt.com/codex/tasks/task_e_6869f0cd0a18833399d8000b1e57f161